### PR TITLE
Main) 랜딩페이지 메뉴 리팩터링(접근제한, 명명)

### DIFF
--- a/src/common/Navbar/PMNavbar.jsx
+++ b/src/common/Navbar/PMNavbar.jsx
@@ -195,7 +195,7 @@ const PMNavbar = () => {
                   <Link to="/myproject/evaluate">팀원 상호 평가</Link>
                 </SubMenuItem>
                 <SubMenuItem>
-                  <Link to="/myproject/landing">랜딩페이지 작성</Link>
+                  <Link to="/myproject/landing">랜딩페이지 작성·보기</Link>
                 </SubMenuItem>
               </SubMenuWrapper>
             </UserNavMenuItem>

--- a/src/common/OBCard/OBCard.css
+++ b/src/common/OBCard/OBCard.css
@@ -6,6 +6,12 @@
 
   background-color: #fafafa;
   overflow: hidden;
+
+  transition: all 0.5s;
+
+  &:hover {
+    transform: translateY(-0.5rem);
+  }
 }
 
 .card-content {

--- a/src/pages/match/Match.jsx
+++ b/src/pages/match/Match.jsx
@@ -10,7 +10,7 @@ import MatchDetail from "./MatchDetail";
 import MatchWrite from "./MatchWrite";
 import { TextAreaProvider } from "../../context/TextAreaProvider";
 import useIntersect from "../../utils/intersectionObserve";
-import { AdminRoute } from "../../routes";
+import { PMRoute } from "../../routes";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
@@ -139,7 +139,7 @@ export default function Match() {
       <Routes>
         <Route path="/" exact element={<MatchHome type={userType} />} />
         <Route path="/detail/*" element={<MatchDetail />} />
-        <Route element={<AdminRoute />}>
+        <Route element={<PMRoute />}>
           <Route path="/new" exact element={<MatchWrite />} />
           <Route path="/modify" exact element={<MatchWrite />} />
         </Route>

--- a/src/pages/myProject/landing/LandingPage.jsx
+++ b/src/pages/myProject/landing/LandingPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { Route, Routes, useLocation } from "react-router-dom";
+import { Route, Routes, Navigate, useLocation } from "react-router-dom";
 import { landingDetailAPI } from "../../../api";
 import useGetAccessToken from "../../../utils/getAccessToken";
 import LandingPageWrite from "./LandingPageWrite";
@@ -18,7 +18,7 @@ export default function LandingPage() {
   const { userType, autoLogin } = useSelector((state) => state.userInfo);
 
   const [data, setData] = useState(null);
-
+  const [isLoading, setIsLoading] = useState(true);
   useEffect(() => {
     if (accessToken !== "") {
       landingDetailAPI(accessToken, dispatch, autoLogin).then((response) => {
@@ -31,16 +31,28 @@ export default function LandingPage() {
         } else if (response.project === null) {
           setData(null);
         }
+        setIsLoading(false);
       });
     }
   }, [location]);
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <>
       <TextAreaProvider>
         <Routes>
-          {userType === "ROLE_PM" && data === null ? (
-            <Route path="/new" element={<LandingPageWrite mode="new" />} />
+          {data === null ? (
+            userType === "ROLE_PM" ? (
+              <Route
+                path="/"
+                element={<Navigate to="/myproject/landing/new" />}
+              />
+            ) : (
+              <Route path="/" element={<Navigate to="/match" />} />
+            )
           ) : (
             <Route
               path="/"
@@ -48,10 +60,18 @@ export default function LandingPage() {
             />
           )}
           <Route
+            path="/new"
+            element={userType === "ROLE_PM" && <LandingPageWrite mode="new" />}
+          />
+          <Route
             path="/modify"
             element={
               userType === "ROLE_PM" && <LandingPageWrite mode="modify" />
             }
+          />
+          <Route
+            path="/"
+            element={<LandingPageDetail project={data} type={userType} />}
           />
         </Routes>
       </TextAreaProvider>


### PR DESCRIPTION
### 애니메이션
- 홈 프로젝트 OBCard hover 시, MatchCard와 마찬가지로 위로 뜨는 듯한 애니메이션 추가 

### Route
- 매칭 프로젝트에 지원(작성)하지 않은 상황에서 랜딩페이지 접근 시, 매칭 프로젝트 페이지로 리다이렉트
- Match 작성•수정 페이지를 PM만 접근 가능한 페이지를 관리자만 접근 가능하도록 구현하여 해당 오류 해결

### Navbar
- 랜딩페이지 작성이란 서브 메뉴 이름에서 작성, 보기 추가