### PR TITLE
🐞 Fix: 같은 css 이름으로 인한 css 중복 문제 해결

### DIFF
--- a/src/components/evaluate/Evaluate.css
+++ b/src/components/evaluate/Evaluate.css
@@ -1,5 +1,5 @@
 /* 전체 컨테이너 */
-.container {
+.evaluate-container {
   display: flex;
   width: 38.4rem;
   height: 22rem;
@@ -8,7 +8,7 @@
 }
 
 /*하얀 색 컨테이너*/
-.detail-container {
+.evaluate-detail-container {
   display: flex;
   flex-direction: column;
   width: 36.8rem;
@@ -19,7 +19,7 @@
 }
 
 /* 헤더 컨테이너 */
-.head-container {
+.evaluate-head-container {
   display: flex;
   flex-direction: row;
   margin: 1.8rem 0 0 2.5rem;

--- a/src/components/evaluate/EvaluateCardDetail.jsx
+++ b/src/components/evaluate/EvaluateCardDetail.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import EvaluateStar from "./EvaluateStar";
-import "./Evaluate.css"
-
+import "./Evaluate.css";
 
 //해당 IMG 컨테이너
 const ImgContainer = styled.div`
@@ -112,9 +111,9 @@ export default function EvaluateCardDetail({
   };
 
   return (
-    <div className="container">
-      <div className="detail-container">
-        <div className="head-container">
+    <div className="evaluate-container">
+      <div className="evaluate-detail-container">
+        <div className="evaluate-head-container">
           <ImgContainer>
             <ProfileImg
               style={{

--- a/src/components/evaluate/MyEvaluationCard.jsx
+++ b/src/components/evaluate/MyEvaluationCard.jsx
@@ -5,8 +5,8 @@ import styled from "styled-components";
 
 export default function MyEvaluationCard({ list }) {
   return (
-    <div className="container">
-      <div className="detail-container">
+    <div className="evaluate-container">
+      <div className="evaluate-detail-container">
         <HeadContainer>
           <EvaluateStar list={list} editOn={false} />
         </HeadContainer>
@@ -17,8 +17,8 @@ export default function MyEvaluationCard({ list }) {
 }
 
 const HeadContainer = styled.div`
-  margin : 2.7rem 0 0 2.4rem;
-`
+  margin: 2.7rem 0 0 2.4rem;
+`;
 
 const TextBox = styled.div`
   margin: 1.1rem 2.4rem 0 2.4rem;

--- a/src/pages/challenger/Challenger.css
+++ b/src/pages/challenger/Challenger.css
@@ -30,11 +30,11 @@
 
   /* 표 카테고리 리스트 */
   .table_title_list {
-    display: flex;
-    flex-basis: 70%;
     box-sizing: border-box;
-    padding: 0 5rem;
+    display: flex;
     justify-content: space-between;
+    flex-basis: 70%;
+    padding: 0 5rem;
   }
 
   /* 표 제목 옵션 부분 */

--- a/src/pages/challenger/Challenger.css
+++ b/src/pages/challenger/Challenger.css
@@ -27,47 +27,47 @@
   border-bottom: 0.1rem solid #e7e6ea;
   color: #e7e6ea;
   margin-right: 2rem;
+}
 
-  /* 표 카테고리 리스트 */
-  .table_title_list {
-    box-sizing: border-box;
-    display: flex;
-    justify-content: space-between;
-    flex-basis: 70%;
-    padding: 0 5rem;
-  }
+/* 표 카테고리 리스트 */
+.table_title_list {
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+  flex-basis: 70%;
+  padding: 0 5rem;
+}
 
-  /* 표 제목 옵션 부분 */
-  .table_title_optioin {
-    display: block;
-    flex-basis: 30%;
-    box-sizing: border-box;
+/* 표 제목 옵션 부분 */
+.table_title_optioin {
+  display: block;
+  flex-basis: 30%;
+  box-sizing: border-box;
+}
 
-    .table_title_select {
-      float: right;
-      min-width: 18rem;
-      box-sizing: border-box;
-      padding-right: 3rem;
-    }
+.table_title_select {
+  float: right;
+  min-width: 18rem;
+  box-sizing: border-box;
+  padding-right: 3rem;
+}
 
-    .table_option_dropdown {
-      float: right;
-    }
-  }
+.table_option_dropdown {
+  float: right;
+}
 
-  /* 표 제목 폰트 스타일 */
-  .table_title {
-    display: flex;
-    justify-content: center;
-    width: 10rem;
-    color: var(--base-50, #e7e6ea);
-    text-align: center;
-    font-family: KBO-Dia-Gothic;
-    font-size: 2.2rem;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 150%;
-  }
+/* 표 제목 폰트 스타일 */
+.table_title {
+  display: flex;
+  justify-content: center;
+  width: 10rem;
+  color: var(--base-50, #e7e6ea);
+  text-align: center;
+  font-family: KBO-Dia-Gothic;
+  font-size: 2.2rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 150%;
 }
 
 /*첼린저 리스트들을 나열하는 박스*/

--- a/src/pages/myPage/MyPage.css
+++ b/src/pages/myPage/MyPage.css
@@ -1,11 +1,11 @@
-.container {
+.myPageContainer {
   display: flex;
   justify-content: center;
   align-items: center;
   min-height: calc(100% - 38rem);
 }
 
-.boxWrapper {
+.profileBoxWrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -119,9 +119,9 @@
     font-size: 1rem;
     cursor: pointer;
     align-items: center;
-    
+
     &:hover {
-      opacity : 0.8;
+      opacity: 0.8;
     }
   }
 }
@@ -140,7 +140,7 @@
   font-size: 1.2rem;
   font-weight: 300;
   &:hover {
-    opacity : 0.8;
+    opacity: 0.8;
   }
 }
 


### PR DESCRIPTION
## 개요
![image](https://github.com/UMC-Matching-Center/U.M.C_Web/assets/71388566/e182259b-15d9-4adf-9c14-94e3e045b2d2)

- mypage.css의 container와 evaluate.css의 container가 같은 이름으로 인해 두개의 css가 모두 적용되는 문제 발생

### 마이페이지 css 중복 적용 문제
- myPage.css 내 container와 같은 단순한 className에 페이지 단어 추가하여 변경
- evaluate.css 내 container와 같은 단순한 className에 페이지 단어 추가하여 변경

어떤 변경사항이 있나요?

- [ ]  새로운 기능 추가
- [X]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).